### PR TITLE
Get Short Sha Action

### DIFF
--- a/deploy-helm/action.yaml
+++ b/deploy-helm/action.yaml
@@ -65,7 +65,7 @@ runs:
 
     - name: Short Sha
       id: short
-      run: echo "::set-output name=sha::${GITHUB_SHA::7}"
+      uses: alehechka-io/kubernetes-actions/get-short-sha@main
       shell: bash
 
     - name: Version
@@ -74,8 +74,8 @@ runs:
       with:
         token: ${{ inputs.token }}
         production_variable: ${{ github.ref_name }}
-        staging_variable: 'v0.0.0-${{ steps.short.outputs.sha }}'
-        development_variable: 'v0.0.0-${{ steps.short.outputs.sha }}'
+        staging_variable: 'v0.0.0-${{ steps.short.outputs.short_sha }}'
+        development_variable: 'v0.0.0-${{ steps.short.outputs.short_sha }}'
 
     - name: Update versions
       run: yq --inplace '.version = "${{ steps.version.outputs.variable }}" | .appVersion = "${{ steps.version.outputs.variable }}"' Chart.yaml

--- a/get-short-sha/README.md
+++ b/get-short-sha/README.md
@@ -1,0 +1,52 @@
+<!-- action-docs-description -->
+## Description
+
+Truncates the commit sha to the first 7 digits
+
+
+<!-- action-docs-description -->
+
+## Example Usage
+
+```yaml
+name: Get Short Sha
+on:
+  - push
+
+jobs:
+  get-short-sha:
+    name: Get Short Sha
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Short Sha
+        id: short
+        uses: alehechka-io/kubernetes-actions/get-short-sha@main
+        shell: bash
+
+      - name: 'Short Sha: ${{ steps.short.outputs.short_sha }}'
+        run: echo "${{ steps.short.outputs.short_sha }}"
+```
+
+<!-- action-docs-inputs -->
+
+<!-- action-docs-inputs -->
+
+<!-- action-docs-outputs -->
+## Outputs
+
+| parameter | description |
+| - | - |
+| short_sha | Shortened Sha |
+
+
+
+<!-- action-docs-outputs -->
+
+<!-- action-docs-runs -->
+## Runs
+
+This action is a `composite` action.
+
+
+<!-- action-docs-runs -->

--- a/get-short-sha/action.yaml
+++ b/get-short-sha/action.yaml
@@ -1,0 +1,15 @@
+name: 'Get Short Sha'
+description: 'Truncates the commit sha to the first 7 digits'
+
+outputs:
+  short_sha:
+    description: 'Shortened Sha'
+    value: ${{ steps.short.outputs.sha }}
+
+runs:
+  using: 'composite'
+  steps:
+    - name: Short Sha
+      id: short
+      run: echo "::set-output name=sha::${GITHUB_SHA::7}"
+      shell: bash


### PR DESCRIPTION
# Overview
Very simple action to truncate the given commit sha and output the shortened 7-digit sha.