### PR TITLE
Conditionally patch namespace with service label

### DIFF
--- a/create-feature-namespace/action.yaml
+++ b/create-feature-namespace/action.yaml
@@ -32,7 +32,7 @@ runs:
       env:
         NAMESPACE: ${{ steps.namespace.outputs.name }}
         REF_NAME: ${{ steps.namespace.outputs.ref }}
-      working-directory: ${{ github.actions_path }}/k8s
+      working-directory: ${{ github.action_path }}/k8s
       shell: bash
 
     - name: Append service label
@@ -42,5 +42,5 @@ runs:
 
           kubectl patch namespace '${{ steps.namespace.outputs.name }}' --patch-file service-label.patch.yaml
         fi
-      working-directory: ${{ github.actions_path }}/k8s
+      working-directory: ${{ github.action_path }}/k8s
       shell: bash

--- a/create-feature-namespace/action.yaml
+++ b/create-feature-namespace/action.yaml
@@ -28,8 +28,19 @@ runs:
 
     - name: Create Feature Namespace
       if: steps.namespace.outputs.exists != 'true'
-      run: cat ${{ github.action_path }}/k8s/feature.namespace.yaml | envsubst | kubectl apply -f -
+      run: cat feature.namespace.yaml | envsubst | kubectl apply -f -
       env:
         NAMESPACE: ${{ steps.namespace.outputs.name }}
         REF_NAME: ${{ steps.namespace.outputs.ref }}
+      working-directory: ${{ github.actions_path }}/k8s
+      shell: bash
+
+    - name: Append service label
+      run: |
+        if [[ $(kubectl get namespace -l ${{ github.repository_owner }}/feature-branch==${{ steps.namespace.outputs.name }} -o name) ]]; then
+          envsubst < service-label.patch.yaml | sponge service-label.patch.yaml
+
+          kubectl patch namespace '${{ steps.namespace.outputs.name }}' --patch-file service-label.patch.yaml
+        fi
+      working-directory: ${{ github.actions_path }}/k8s
       shell: bash

--- a/create-feature-namespace/k8s/service-label.patch.yaml
+++ b/create-feature-namespace/k8s/service-label.patch.yaml
@@ -1,0 +1,3 @@
+metadata:
+  labels:
+    $GITHUB_REPOSITORY: ''


### PR DESCRIPTION
# Overview
After "creating" a feature namespace, the create-feature-namespace action will now conditionally patch the namespace with a new repository label. This will help dramatically with specifying label selectors for kube-external-sync.

Related to: 
- https://github.com/alehechka-io/auth-middleware/issues/21