### PR TITLE
Deploy Helm charts with environment

### DIFF
--- a/deploy-helm/README.md
+++ b/deploy-helm/README.md
@@ -55,6 +55,7 @@ jobs:
 | namespace | Name of Namespace that was deployed to. |
 | chart_version | Version of the Helm chart that was deployed |
 | hostname | Hostname provided to deployed Helm chart |
+| environment | Environment used to deploy Helm chart |
 
 
 

--- a/deploy-helm/action.yaml
+++ b/deploy-helm/action.yaml
@@ -47,6 +47,10 @@ outputs:
     description: 'Hostname provided to deployed Helm chart'
     value: ${{ steps.hostname.outputs.value }}
 
+  environment:
+    description: Environment used to deploy Helm chart
+    value: ${{ steps.version.outputs.environment }}
+
 runs:
   using: composite
   steps:

--- a/deploy-helm/action.yaml
+++ b/deploy-helm/action.yaml
@@ -83,7 +83,7 @@ runs:
 
     - name: Update values
       run: |
-        yq --inplace '.image.tag = "${{ inputs.image_tag }}"' values.yaml
+        yq --inplace '.image.tag = "${{ inputs.image_tag }}", .environment = "${{ steps.version.outputs.environment }}"' values.yaml
         envsubst < values.yaml | sponge values.yaml
       working-directory: ${{ inputs.chart_path }}
       shell: bash

--- a/deploy-helm/charts/example/values.yaml
+++ b/deploy-helm/charts/example/values.yaml
@@ -4,6 +4,8 @@
 
 replicaCount: 1
 
+environment: local
+
 image:
   repository: nginx
   pullPolicy: IfNotPresent


### PR DESCRIPTION
# Overview
- Setting `environment` in values.yaml prior to deploying Helm chart
- Outputting determined environment for easy use