### PR TITLE
Resolve PR SHAs not matching commit SHA

### DIFF
--- a/.github/workflows/test-get-short-sha.yaml
+++ b/.github/workflows/test-get-short-sha.yaml
@@ -1,0 +1,26 @@
+name: Test get-short-sha
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - 'get-short-sha/**/*'
+      - '.github/workflows/test-get-short-sha.yaml'
+
+jobs:
+  test-get-short-sha:
+    name: Test get short sha
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Get Short Sha
+        id: short
+        uses: ./get-short-sha
+
+      - name: 'Short Sha: ${{ steps.short.outputs.short_sha }}'
+        run: echo "${{ steps.short.outputs.short_sha }}"

--- a/get-short-sha/action.yaml
+++ b/get-short-sha/action.yaml
@@ -11,5 +11,14 @@ runs:
   steps:
     - name: Short Sha
       id: short
-      run: echo "::set-output name=sha::${GITHUB_SHA::7}"
+      run: |
+        if [ "${{ github.event_name }}" = "pull_request" ]; then
+          SHA="${{ github.event.pull_request.head.sha }}"
+
+        else
+          SHA="${{ github.sha }}"
+          
+        fi
+
+        echo "::set-output name=sha::${SHA::7}"
       shell: bash


### PR DESCRIPTION
# Overview
It was found through testing that when a workflow is triggered via PR, the provided `${{ github.sha }}` is for a merge between the latest commit and the base branch. This makes it difficult to locate which commit the Docker image/Helm chart actually deployed from because that PR sha is not readily available. 

This change checks to see if the workflow was triggered by PR, and if so will use the head commit sha instead.