### PR TITLE
Resolve extraneous environment creation

### DIFF
--- a/.github/workflows/inactive-deployment.yaml
+++ b/.github/workflows/inactive-deployment.yaml
@@ -15,4 +15,4 @@ jobs:
         uses: ./deployment-status
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          step: delete-env
+          step: deactivate-env

--- a/.github/workflows/test-deployment-status.yaml
+++ b/.github/workflows/test-deployment-status.yaml
@@ -30,3 +30,4 @@ jobs:
           deployment_id: ${{ steps.deployment.outputs.deployment_id }}
           step: finish
           env_url: https://example.com
+          auto_inactive: 'true'

--- a/deployment-status/README.md
+++ b/deployment-status/README.md
@@ -62,7 +62,7 @@ jobs:
         uses: alehechka-io/kubernetes-actions/deployment-status@main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          step: delete-env
+          step: deactivate-env
 ```
 
 <!-- action-docs-inputs -->
@@ -76,6 +76,7 @@ jobs:
 | step | One of 'start', 'finish', 'deactivate-env', or 'delete-env' | `true` |  |
 | status | The deployment status (for `finish` only) | `false` | ${{ job.status }} |
 | env_url | The environment URL (for `finish` only) | `false` |  |
+| auto_inactive | Whether to mark existing deployments as inactive if a deployment succeeds (for `finish` only) | `false` | false |
 
 
 

--- a/deployment-status/action.yaml
+++ b/deployment-status/action.yaml
@@ -51,7 +51,7 @@ runs:
       with:
         token: ${{ inputs.token }}
         step: ${{ inputs.step }}
-        env: ${{ steps.environment.outputs.variable }}
+        env: ${{ input.environment }}
         env_url: ${{ inputs.env_url }}
         ref: ${{ steps.ref.outputs.name }}
         deployment_id: ${{ inputs.deployment_id }}

--- a/deployment-status/action.yaml
+++ b/deployment-status/action.yaml
@@ -6,6 +6,11 @@ inputs:
     description: 'Deployment ID of previous deployment to update'
     required: false
 
+  environment:
+    description: 'Environment of Deployment'
+    required: false
+    default: development
+
   token:
     description: GITHUB_TOKEN to access the GitHub API if the repository is private
     required: false
@@ -23,13 +28,15 @@ inputs:
     required: false
     description: The environment URL (for `finish` only)
 
+  auto_inactive:
+    description: Whether to mark existing deployments as inactive if a deployment succeeds (for `finish` only)
+    default: 'false'
+    required: false
+
 outputs:
   deployment_id:
     description: 'Deployment ID of deployment updated or created'
     value: ${{ steps.deployment.outputs.deployment_id }}
-  environment:
-    description: 'Deployment environment'
-    value: ${{ steps.environment.outputs.variable }}
 
 runs:
   using: 'composite'
@@ -37,15 +44,6 @@ runs:
     - name: Get Ref
       id: ref
       uses: alehechka-io/kubernetes-actions/get-ref@main
-
-    - name: Get Environment
-      id: environment
-      uses: alehechka-io/kubernetes-actions/determine-environment@main
-      with:
-        token: ${{ inputs.token }}
-        production_variable: 'production'
-        staging_variable: 'staging'
-        development_variable: '${{ steps.ref.outputs.name }}'
 
     - name: Deployment Status
       id: deployment
@@ -58,4 +56,4 @@ runs:
         ref: ${{ steps.ref.outputs.name }}
         deployment_id: ${{ inputs.deployment_id }}
         status: ${{ inputs.status }}
-        auto_inactive: true
+        auto_inactive: ${{ inputs.auto_inactive }}

--- a/deployment-status/action.yaml
+++ b/deployment-status/action.yaml
@@ -51,7 +51,7 @@ runs:
       with:
         token: ${{ inputs.token }}
         step: ${{ inputs.step }}
-        env: ${{ input.environment }}
+        env: ${{ inputs.environment }}
         env_url: ${{ inputs.env_url }}
         ref: ${{ steps.ref.outputs.name }}
         deployment_id: ${{ inputs.deployment_id }}


### PR DESCRIPTION
# Overview
Apparently when a deployment environment is created, and later deleted, the actual environment is not deleted with it. Previously I set this workflow up to set the env automatically based on the determined env or the branch name if development. Now this action will rely on an inputted env and inputted auto_inactive flag.