### PR TITLE
Feature Namespace Label Management

### DIFF
--- a/cleanup-deleted-branch/action.yaml
+++ b/cleanup-deleted-branch/action.yaml
@@ -42,6 +42,11 @@ runs:
           || true
       shell: bash
 
+    - name: Remove Namespace label
+      if: steps.namespace.outputs.exists == 'true'
+      run: kubectl label namespace ${{ github.repository }}-
+      shell: bash
+
     - name: Get Helm Secrets
       if: steps.namespace.outputs.exists == 'true'
       id: secrets

--- a/create-feature-namespace/action.yaml
+++ b/create-feature-namespace/action.yaml
@@ -38,9 +38,7 @@ runs:
     - name: Append service label
       run: |
         if [[ $(kubectl get namespace -l ${{ github.repository_owner }}/feature-branch==${{ steps.namespace.outputs.name }} -o name) ]]; then
-          envsubst < service-label.patch.yaml | sponge service-label.patch.yaml
-
-          kubectl patch namespace '${{ steps.namespace.outputs.name }}' --patch-file service-label.patch.yaml
+          kubectl label namespace ${{ steps.namespace.outputs.name }} ${{ github.repository }}=''
         fi
       working-directory: ${{ github.action_path }}/k8s
       shell: bash

--- a/create-feature-namespace/k8s/service-label.patch.yaml
+++ b/create-feature-namespace/k8s/service-label.patch.yaml
@@ -1,3 +1,0 @@
-metadata:
-  labels:
-    $GITHUB_REPOSITORY: ''


### PR DESCRIPTION
# Overview
It was found that when a feature branch is deleted and thus triggers the cleanup branch action if the Namespace still has Helm deploys and thus doesn't get deleted, the Helm chart that was deleted will not re-sync the ExternalName resources.

- create-feature-namespace action updated to more simply add the repository label
- cleanup-deleted-branch updated with new step to remove repository label from feature namespace