### PR TITLE
Resolve feature namespace race condition

### DIFF
--- a/create-feature-namespace/action.yaml
+++ b/create-feature-namespace/action.yaml
@@ -36,6 +36,7 @@ runs:
       shell: bash
 
     - name: Append service label
+      if: steps.namespace.outputs.exists == 'true'
       run: |
         if [[ $(kubectl get namespace -l ${{ github.repository_owner }}/feature-branch==${{ steps.namespace.outputs.name }} -o name) ]]; then
           kubectl label namespace ${{ steps.namespace.outputs.name }} ${{ github.repository }}=''

--- a/create-feature-namespace/k8s/feature.namespace.yaml
+++ b/create-feature-namespace/k8s/feature.namespace.yaml
@@ -4,6 +4,7 @@ metadata:
   name: $NAMESPACE
   labels:
     $GITHUB_REPOSITORY_OWNER/feature-branch: $NAMESPACE
+    $GITHUB_REPOSITORY: ''
   annotations:
     $GITHUB_REPOSITORY_OWNER/feature-branch: $REF_NAME
     $GITHUB_REPOSITORY_OWNER/feature-service: $GITHUB_REPOSITORY


### PR DESCRIPTION
# Overview
Description of problem can be found in #38. Solution is to supply the service label during feature namespace creation. Additionally, the appended service label is only applied if the namespace exists prior to workflow run.

Closes: #38 